### PR TITLE
Dynamicroles

### DIFF
--- a/download-add.php
+++ b/download-add.php
@@ -167,7 +167,7 @@ if( ! empty( $_POST['do'] ) ) {
                         
                        
                     </select> -->
-                     <?php generate_user_roles_select(); ?>
+                     <?php downloads_generate_user_roles_select(); ?>
                 </td>
             </tr>
             <tr>

--- a/download-add.php
+++ b/download-add.php
@@ -72,9 +72,10 @@ if( ! empty( $_POST['do'] ) ) {
             $file_timestamp_minute = ! empty( $_POST['file_timestamp_minute'] ) ? intval( $_POST['file_timestamp_minute'] ) : 0;
             $file_timestamp_second = ! empty( $_POST['file_timestamp_second'] ) ? intval( $_POST['file_timestamp_second'] ) : 0;
             $file_date = gmmktime($file_timestamp_hour, $file_timestamp_minute, $file_timestamp_second, $file_timestamp_month, $file_timestamp_day, $file_timestamp_year);
-            $file_permission = ! empty( $_POST['file_permission'] ) ? intval( $_POST['file_permission'] ) : 0;
+            $file_permission = "'" . get_file_permissions_info(). "'";
             $addfile = $wpdb->query("INSERT INTO $wpdb->downloads VALUES (0, '$file', '$file_name', '$file_des', '$file_size', $file_category, '$file_date', '$file_date', '$file_date', $file_hits, $file_permission)");
             if(!$addfile) {
+                $wpdb->print_error();
                 $text = '<p style="color: red;">'.sprintf(__('Error In Adding File \'%s (%s)\'', 'wp-downloadmanager'), $file_name, $file).'</p>';
             } else {
                 $file_id = intval($wpdb->insert_id);
@@ -153,7 +154,9 @@ if( ! empty( $_POST['do'] ) ) {
             <tr>
                 <td><strong><?php _e('Allowed To Download:', 'wp-downloadmanager') ?></strong></td>
                 <td>
+                    <!--
                     <select name="file_permission" size="1">
+                        
                         <option value="-2"><?php _e('Hidden', 'wp-downloadmanager'); ?></option>
                         <option value="-1" selected="selected"><?php _e('Everyone', 'wp-downloadmanager'); ?></option>
                         <option value="0"><?php _e('Registered Users Only', 'wp-downloadmanager'); ?></option>
@@ -161,7 +164,10 @@ if( ! empty( $_POST['do'] ) ) {
                         <option value="2"><?php _e('At Least Author Role', 'wp-downloadmanager'); ?></option>
                         <option value="7"><?php _e('At Least Editor Role', 'wp-downloadmanager'); ?></option>
                         <option value="10"><?php _e('At Least Administrator Role', 'wp-downloadmanager'); ?></option>
-                    </select>
+                        
+                       
+                    </select> -->
+                     <?php generate_user_roles_select(); ?>
                 </td>
             </tr>
             <tr>

--- a/download-manager.php
+++ b/download-manager.php
@@ -344,15 +344,7 @@ switch($mode) {
                     <tr>
                         <td><strong><?php _e('Allowed To Download:', 'wp-downloadmanager') ?></strong></td>
                         <td>
-                            <select name="file_permission" size="1">
-                                <option value="-2" <?php selected('-2', $file->file_permission); ?>><?php _e('Hidden', 'wp-downloadmanager'); ?></option>
-                                <option value="-1" <?php selected('-1', $file->file_permission); ?>><?php _e('Everyone', 'wp-downloadmanager'); ?></option>
-                                <option value="0" <?php selected('0', $file->file_permission); ?>><?php _e('Registered Users Only', 'wp-downloadmanager'); ?></option>
-                                <option value="1" <?php selected('1', $file->file_permission); ?>><?php _e('At Least Contributor Role', 'wp-downloadmanager'); ?></option>
-                                <option value="2" <?php selected('2', $file->file_permission); ?>><?php _e('At Least Author Role', 'wp-downloadmanager'); ?></option>
-                                <option value="7" <?php selected('7', $file->file_permission); ?>><?php _e('At Least Editor Role', 'wp-downloadmanager'); ?></option>
-                                <option value="10" <?php selected('10', $file->file_permission); ?>><?php _e('At Least Administrator Role', 'wp-downloadmanager'); ?></option>
-                            </select>
+                            <?php generate_user_roles_select(); ?>
                         </td>
                     </tr>
                     <tr>

--- a/download-manager.php
+++ b/download-manager.php
@@ -344,7 +344,7 @@ switch($mode) {
                     <tr>
                         <td><strong><?php _e('Allowed To Download:', 'wp-downloadmanager') ?></strong></td>
                         <td>
-                            <?php generate_user_roles_select(); ?>
+                            <?php generate_user_roles_select( $file->file_permission, $mode ); ?>
                         </td>
                     </tr>
                     <tr>

--- a/download-manager.php
+++ b/download-manager.php
@@ -344,7 +344,7 @@ switch($mode) {
                     <tr>
                         <td><strong><?php _e('Allowed To Download:', 'wp-downloadmanager') ?></strong></td>
                         <td>
-                            <?php generate_user_roles_select( $file->file_permission, $mode ); ?>
+                            <?php downloads_generate_user_roles_select( $file->file_permission, $mode ); ?>
                         </td>
                     </tr>
                     <tr>

--- a/download-manager.php
+++ b/download-manager.php
@@ -189,7 +189,7 @@ if(!empty($_POST['do'])) {
                 $file_timestamp_second = ! empty( $_POST['file_timestamp_second'] ) ? intval( $_POST['file_timestamp_second'] ) : 0;
                 $timestamp_sql = ", file_date = '".gmmktime($file_timestamp_hour, $file_timestamp_minute, $file_timestamp_second, $file_timestamp_month, $file_timestamp_day, $file_timestamp_year)."'";
             }
-            $file_permission = ! empty( $_POST['file_permission'] ) ? intval( $_POST['file_permission'] ) : 0;
+            $file_permission = "'" . get_file_permissions_info() . "'";
             $file_updated_date = current_time('timestamp');
             $editfile = $wpdb->query("UPDATE $wpdb->downloads SET $file_sql file_name = '$file_name', file_des = '$file_des', $file_size_sql file_category = $file_category, file_permission = $file_permission, file_updated_date = '$file_updated_date' $timestamp_sql $hits_sql WHERE file_id = $file_id;");
             if(!$editfile) {

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1623,11 +1623,7 @@ function can_download_file( $permissions ) {
 	foreach ( $roles as $role ) {
 		if ( in_array( $role, $user_roles ) ) {
 			$allowed = true;
-<<<<<<< HEAD
 			return $allowed;
-=======
-			return;
->>>>>>> f4556218f13ab1c8202147b1cf35e7249066e73f
 		}
 	}
 

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1577,13 +1577,18 @@ function downloadmanager_activate() {
 	flush_rewrite_rules();
 }
 
-function generate_user_roles_select() {
+function generate_user_roles_select( $permission = array(), $mode = 'create' ) {
+
 	$wp_roles = wp_roles();
 	echo 'Administrators will have access to all downloads, that can\'t be protected. <br />';
 	$select = '<select name="file_permission[]" multiple>';
 	$options = '';
+	if ($mode == 'edit' ) {
+		$permission = explode( '+', $permission );
+	}
 	foreach ($wp_roles->role_names as $slug => $name ) {
-		$html = '<option value="' . $slug . '">' . $name . '</option>';
+		$selected = (in_array( $slug, $permission )) ? 'selected' : '';
+		$html = '<option value="' . $slug . '" ' . $selected . '>' . $name . '</option>';
 		$options .= $html;
 	}
 	$options .= '<option value="-1">Everyone</option>';

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1621,7 +1621,10 @@ function can_download_file( $permissions ) {
 	$user_roles = $current_user->roles;
 	$allowed = false;
 	foreach ( $roles as $role ) {
-		$allowed = ( in_array( $role, $user_roles ) ) ? true : false;
+		if ( in_array( $role, $user_roles ) ) {
+			$allowed = true;
+			return;
+		}
 	}
 
 	return $allowed;

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1621,7 +1621,10 @@ function can_download_file( $permissions ) {
 	$user_roles = $current_user->roles;
 	$allowed = false;
 	foreach ( $roles as $role ) {
-		$allowed = ( in_array( $role, $user_roles ) ) ? true : false;
+		if ( in_array( $role, $user_roles ) ) {
+			$allowed = true;
+			return $allowed;
+		}
 	}
 
 	return $allowed;

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1577,17 +1577,17 @@ function downloadmanager_activate() {
 	flush_rewrite_rules();
 }
 
-function generate_user_roles_select( $permission = array(), $mode = 'create' ) {
+function downloads_generate_user_roles_select( $permission = array(), $mode = 'create' ) {
 
 	$wp_roles = wp_roles();
 	echo 'Administrators will have access to all downloads, that can\'t be protected. <br />';
 	$select = '<select name="file_permission[]" multiple>';
 	$options = '';
-	if ($mode == 'edit' ) {
+	if ( $mode == 'edit' ) {
 		$permission = explode( '+', $permission );
 	}
 	foreach ($wp_roles->role_names as $slug => $name ) {
-		$selected = (in_array( $slug, $permission )) ? 'selected' : '';
+		$selected = ( in_array( $slug, $permission ) ) ? 'selected' : '';
 		$html = '<option value="' . $slug . '" ' . $selected . '>' . $name . '</option>';
 		$options .= $html;
 	}
@@ -1598,10 +1598,11 @@ function generate_user_roles_select( $permission = array(), $mode = 'create' ) {
 }
 
 function get_file_permissions_info() {
-	if ( ! empty( $_POST['file_permission'] ) ) {
+	$permissions = filter_var( $_POST['file_permission'], FILTER_SANITIZE_STRING );
+	if ( ! empty( $permissions ) ) {
 		$permissions = $_POST['file_permission'];
 		if ( is_array( $permissions) ) {
-			return implode('+', $permissions );
+			return implode( '+', $permissions );
 		}
 		return $permissions;
 	} 
@@ -1609,13 +1610,13 @@ function get_file_permissions_info() {
 }
 
 function can_download_file( $permissions ) {
-	$roles = explode('+', $permissions );
+	$roles = explode( '+', $permissions );
 	$roles[] = 'administrator';
 	$current_user = wp_get_current_user();
 	$user_roles = $current_user->roles;
 	$allowed = false;
 	foreach ( $roles as $role ) {
-		$allowed = (in_array( $role, $user_roles)) ? true : false;
+		$allowed = ( in_array( $role, $user_roles ) ) ? true : false;
 	}
 
 	return $allowed;

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1598,7 +1598,12 @@ function downloads_generate_user_roles_select( $permission = array(), $mode = 'c
 }
 
 function get_file_permissions_info() {
-	$permissions = filter_var( $_POST['file_permission'], FILTER_SANITIZE_STRING );
+	$permissoins_post = $_POST['file_permission'];
+	$permissions = array();
+	foreach ( $permissoins_post as $permission ) {
+		$permissions[] = filter_var( $permission, FILTER_SANITIZE_STRING );
+	}
+	
 	if ( ! empty( $permissions ) ) {
 		$permissions = $_POST['file_permission'];
 		if ( is_array( $permissions) ) {


### PR DESCRIPTION
Custom roles can now be selected for file permissions. Previously it was hard coded and only General Roles were available for file permissions.

From now on any custom role added, shows up for file permissions drop box. 

It is a multiple select box now, you can choose all the users you want to grant permissions to download file. Administrator have permission to download all the files by default.