### PR TITLE
feat: Upload files over API

### DIFF
--- a/download-add.php
+++ b/download-add.php
@@ -3,8 +3,8 @@ require_once( $_SERVER['DOCUMENT_ROOT'] . '/wp-load.php' );
 
 ### Check Whether User Can Manage Downloads
 function authenticate() {
-    $token = get_option('download_api_token'); // Assuming you have stored the token in WordPress options
-    $headers = getallheaders(); // Get all headers
+    $token = get_option('download_api_token');
+    $headers = getallheaders();
 
     if (isset($headers['x-wp-download-token']) && $headers['x-wp-download-token'] === $token) {
         return true;
@@ -101,11 +101,11 @@ if( ! empty( $_POST['do'] ) ) {
 				$addfile = $wpdb->query("INSERT INTO $wpdb->downloads VALUES (0, '$file', '$file_name', '$file_des', '$file_size', $file_category, '$file_date', '$file_date', '$file_date', $file_hits, $file_permission)");
 				if(!$addfile) {
 					$text = '<p style="color: red;">'.sprintf(__('Error In Adding File \'%s (%s)\'', 'wp-downloadmanager'), $file_name, $file).'</p>';
-					$json = array("error" => sprintf(__('Error In Adding File \'%s (%s)\'', 'wp-downloadmanager'), $file_name, $file));
+					$json = array("error" => sprintf('Error In Adding File %s (%s)', $file_name, $file));
 				} else {
 					$file_id = intval($wpdb->insert_id);
 					$text = '<p style="color: green;">'.sprintf(__('File \'%s (%s) (ID: %s)\' Added Successfully', 'wp-downloadmanager'), $file_name, $file, $file_id).'</p>';
-					$json = array("success" => sprintf(__('File \'%s (%s) (ID: %s)\' Added Successfully', 'wp-downloadmanager'), $file_name, $file, $file_id));
+					$json = array("success" => sprintf('File %s (%s) (ID: %s) Added Successfully', $file_name, $file, $file_id));
 				}
 			}
 			break;

--- a/download-options.php
+++ b/download-options.php
@@ -17,6 +17,7 @@ if(! empty( $_POST['Submit'] ) ) {
     $download_path_url = ! empty( $_POST['download_path_url'] ) ? sanitize_text_field( $_POST['download_path_url'] ) : '';
     $download_page_url = ! empty( $_POST['download_page_url'] ) ? sanitize_text_field( $_POST['download_page_url'] ) : '';
     $download_nice_permalink = ! empty( $_POST['download_nice_permalink'] ) ? intval( $_POST['download_nice_permalink'] ) : 0;
+    $download_api_token = ! empty( $_POST['download_api_token'] ) ? sanitize_text_field( $_POST['download_api_token'] ) : bin2hex(openssl_random_pseudo_bytes(32));
     $download_options_use_filename =  ! empty( $_POST['download_options_use_filename'] ) ? intval( $_POST['download_options_use_filename'] ) : 0;
     $download_options_rss_sortby =  ! empty( $_POST['download_options_rss_sortby'] ) ? sanitize_text_field( $_POST['download_options_rss_sortby'] ) : '';
     $download_options_rss_limit =  ! empty( $_POST['download_options_rss_limit'] ) ? intval( $_POST['download_options_rss_limit'] ) : 0;
@@ -47,6 +48,7 @@ if(! empty( $_POST['Submit'] ) ) {
     $update_download_queries[] = update_option('download_method', $download_method);
     $update_download_queries[] = update_option('download_categories', $download_categories);
     $update_download_queries[] = update_option('download_sort', $download_sort);
+    $update_download_queries[] = update_option('download_api_token', $download_api_token);
     $update_download_text[] = __('Download Path', 'wp-downloadmanager');
     $update_download_text[] = __('Download Path URL', 'wp-downloadmanager');
     $update_download_text[] = __('Download Page URL', 'wp-downloadmanager');
@@ -55,6 +57,7 @@ if(! empty( $_POST['Submit'] ) ) {
     $update_download_text[] = __('Download Method', 'wp-downloadmanager');
     $update_download_text[] = __('Download Categories', 'wp-downloadmanager');
     $update_download_text[] = __('Download Sorting', 'wp-downloadmanager');
+    $update_download_text[] = __('Download API Token', 'wp-downloadmanager');
     $i=0;
     $text = '';
     foreach($update_download_queries as $update_download_query) {
@@ -100,6 +103,10 @@ $download_options = get_option('download_options');
              <tr valign="top">
                 <th><?php _e('Download Path:', 'wp-downloadmanager'); ?></th>
                 <td><input type="text" name="download_path" value="<?php echo esc_attr( removeslashes( get_option( 'download_path' ) ) ); ?>" size="50" dir="ltr" /><br /><?php _e('The absolute path to the directory where all the files are stored (without trailing slash).', 'wp-downloadmanager'); ?></td>
+            </tr>
+             <tr valign="top">
+                <th><?php _e('API Token:', 'wp-downloadmanager'); ?></th>
+                <td><input type="text" name="download_api_token" value="<?php echo esc_attr( removeslashes( get_option( 'download_api_token' ) ) ); ?>" size="50" dir="ltr" /><br /><?php _e('API Token to upload files over HTTP API. To generate a secure token run "openssl rand -hex 32" in your terminal.', 'wp-downloadmanager'); ?></td>
             </tr>
              <tr valign="top">
                 <th><?php _e('Download Path URL:', 'wp-downloadmanager'); ?></th>

--- a/wp-downloadmanager.php
+++ b/wp-downloadmanager.php
@@ -1559,6 +1559,8 @@ function downloadmanager_activate() {
 		add_option('download_path', WP_CONTENT_DIR.'/files', 'Download Path');
 		add_option('download_path_url', content_url('files'), 'Download Path URL');
 	}
+	$api_token = bin2hex(openssl_random_pseudo_bytes(32));
+	add_option('download_api_token', $api_token, 'Download API Token');
 	add_option('download_page_url', site_url('downloads'), 'Download Page URL');
 	add_option('download_method', 1, 'Download Type');
 	add_option('download_categories', array('General'), 'Download Categories');


### PR DESCRIPTION
This PR adds an option to upload files via API. It generates a secure random token for authenticating upload requests. 
This was primarily developed for automating file uploads in GitHub CI. reference [PR](https://github.com/Mudlet/Mudlet/pull/7062)

![image](https://github.com/lesterchan/wp-downloadmanager/assets/62795688/6824fd8f-dbaf-4287-b5fc-c8cfbf5da3a5)
