### PR TITLE
Confine a download's path, and check where a remote host resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ wrapper and leave `%FILE_ICON%` on its own.
 
 ## Changelog
 ### 2.0.0
+* FIXED: The Browse source stored whatever file name was posted, and the download endpoint read it. A name climbing out of the downloads directory — `/../../../wp-config.php` — was accepted by Add File and served to anyone, because the stored name is a relative path and neither `sanitize_text_field()` nor the character filter that follows it touches `.` or `/`. Add File now refuses such a name, and the endpoint resolves the path and confirms it is inside the downloads directory before reading a byte, so a row written by anything else is refused too
+* FIXED: A remote file URL was checked for its scheme and its port and nothing else, so `http://169.254.169.254/latest/meta-data/` and `http://127.0.0.1/` were both accepted — and the endpoint proxies a remote file with `readfile()`, which is not `wp_safe_remote_get()` and makes none of the checks WordPress otherwise would. The host must now resolve outside this network, it is checked again when the file is served rather than only when it is saved, and redirects are no longer followed. `wp_downloadmanager_host_is_public` is the escape hatch for a mirror that genuinely is on the local network
 * BREAKING: Requires WordPress 6.8 and PHP 8.2, up from 6.0 and 7.4.
 * BREAKING: The `downloads_page` filter is now `wp_downloadmanager_page` and the `download_embedded` filter is now `wp_downloadmanager_embedded`. The old names are gone.
 * BREAKING: The nineteen `download_*` option rows are consolidated into `wp_downloadmanager_options`, and the schema marker into `wp_downloadmanager_version`. Settings are migrated automatically and the old rows deleted.

--- a/includes/class-wp-downloadmanager-admin.php
+++ b/includes/class-wp-downloadmanager-admin.php
@@ -894,6 +894,19 @@ class WP_DownloadManager_Admin {
 
 			default:
 				$file = isset( $post['file'] ) ? trim( sanitize_text_field( $post['file'] ) ) : '';
+
+				/*
+				 * The Browse select offers only files inside the downloads
+				 * directory, but the value is a request field like any other and
+				 * nothing checked it. sanitize_text_field() does not touch "."
+				 * or "/", and rename_file() below keeps both on purpose, so
+				 * "/../../wp-config.php" reached the row unchanged -- and the
+				 * download endpoint reads the row's path.
+				 */
+				if ( '' !== $file && ! WP_DownloadManager_File::is_safe_relative_file( $file ) ) {
+					return new WP_Error( 'file', __( 'That file is not inside the downloads directory.', 'wp-downloadmanager' ) );
+				}
+
 				$file = WP_DownloadManager_File::rename_file( $path, $file );
 
 				return array(

--- a/includes/class-wp-downloadmanager-file.php
+++ b/includes/class-wp-downloadmanager-file.php
@@ -257,6 +257,79 @@ class WP_DownloadManager_File {
 			return false;
 		}
 
+		if ( empty( $parsed['host'] ) || ! self::host_is_public( $parsed['host'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a host resolves somewhere outside this network.
+	 *
+	 * The scheme and port checks above cannot make this one, and it is the one
+	 * that matters: with a default port, `http://169.254.169.254/latest/meta-data/`
+	 * and `http://127.0.0.1/` satisfy both of them. The download endpoint
+	 * proxies a remote file with readfile(), which is a raw stream wrapper and
+	 * not wp_safe_remote_get(), so nothing else on the path performs the check
+	 * WordPress would normally have made.
+	 *
+	 * Every A record is tested, not just the first, so a name answering with one
+	 * public and one private address is refused rather than accepted on a coin
+	 * toss. A host with no A record at all is refused too: this cannot resolve
+	 * AAAA portably, and refusing an IPv6-only mirror is the safe way to be
+	 * wrong.
+	 *
+	 * This is checked when the row is saved and again when the file is served,
+	 * because the answer can change between the two.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $host Host from the remote URL.
+	 * @return bool
+	 */
+	public static function host_is_public( $host ) {
+		$host  = trim( (string) $host, '[]' );
+		$flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+
+		/**
+		 * Filters whether a remote file's host counts as reachable.
+		 *
+		 * The escape hatch for a site whose mirror genuinely is on the local
+		 * network, and for one behind split-horizon DNS where the lookup this
+		 * server makes is not the one that matters. Returning true for a host
+		 * turns off the check that stops the download endpoint being pointed at
+		 * a metadata service, so return it for one host rather than for all.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param bool|null $is_public Null to run the usual check.
+		 * @param string    $host      Host from the remote URL.
+		 */
+		$filtered = apply_filters( 'wp_downloadmanager_host_is_public', null, $host );
+
+		if ( null !== $filtered ) {
+			return (bool) $filtered;
+		}
+
+		// A literal address needs no lookup. A name does, and the lookup is the
+		// point -- "internal.example.com" is only recognisable by where it goes.
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return (bool) filter_var( $host, FILTER_VALIDATE_IP, $flags );
+		}
+
+		$addresses = gethostbynamel( $host );
+
+		if ( empty( $addresses ) ) {
+			return false;
+		}
+
+		foreach ( $addresses as $address ) {
+			if ( ! filter_var( $address, FILTER_VALIDATE_IP, $flags ) ) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 
@@ -467,6 +540,92 @@ class WP_DownloadManager_File {
 	}
 
 	/**
+	 * Whether a stored file name stays inside the downloads directory.
+	 *
+	 * The Browse source stores a path *relative to the downloads directory*
+	 * rather than a bare file name, because subfolders are a feature -- so it
+	 * cannot be reduced with basename() the way an upload's name is, and
+	 * rename_file() below is not a confinement either. That filter keeps "."
+	 * and "/" precisely because a relative path needs both, so
+	 * "/../../wp-config.php" passes through it byte for byte.
+	 *
+	 * This is a check on the *name*, and it deliberately does not require the
+	 * file to exist: the Add File screen has always accepted a name for a file
+	 * that is not there yet, and stores it with a size of zero.
+	 * safe_file_path() is the check on the resolved path, for the moment the
+	 * bytes are actually read.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $file Stored file name, relative to the downloads directory.
+	 * @return bool
+	 */
+	public static function is_safe_relative_file( $file ) {
+		$file = str_replace( '\\', '/', (string) $file );
+
+		if ( '' === $file || false !== strpos( $file, "\0" ) ) {
+			return false;
+		}
+
+		// One leading slash is the stored convention ("/brochure.pdf"). Two is
+		// an absolute path on some systems and "//host/share" on others.
+		if ( 0 === strpos( $file, '//' ) ) {
+			return false;
+		}
+
+		// Segment by segment rather than strpos( $file, '..' ), which would
+		// also refuse the perfectly ordinary "release..2.zip".
+		foreach ( explode( '/', $file ) as $segment ) {
+			if ( '..' === $segment ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolve a stored file name to a real file inside the downloads directory.
+	 *
+	 * The read-side counterpart of safe_subfolder(), and it exists for the same
+	 * reason: the value arrives from a request and is stored, so the only check
+	 * that means anything is resolving both ends and confirming the file really
+	 * sits inside the folder.
+	 *
+	 * Done here rather than in the caller so that no later caller can hand the
+	 * endpoint a path nothing has checked -- and it runs even for a row written
+	 * by something other than the Add File screen, which is where a crafted
+	 * value would come from once the screen refuses one.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $file_path Downloads directory.
+	 * @param string $file      Stored file name, relative to that directory.
+	 * @return string|false Absolute path, or false when it is not a file inside
+	 *                      the downloads directory.
+	 */
+	public static function safe_file_path( $file_path, $file ) {
+		if ( ! self::is_safe_relative_file( $file ) ) {
+			return false;
+		}
+
+		$file      = str_replace( '\\', '/', (string) $file );
+		$real_base = realpath( $file_path );
+		$real_file = realpath( rtrim( $file_path, '/' ) . '/' . ltrim( $file, '/' ) );
+
+		if ( false === $real_base || false === $real_file ) {
+			return false;
+		}
+
+		// The separator matters: without it /files-public would pass as /files.
+		if ( 0 !== strpos( $real_file, rtrim( $real_base, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR ) ) {
+			return false;
+		}
+
+		return is_file( $real_file ) ? $real_file : false;
+	}
+
+	/**
 	 * Strip characters that do not belong in a stored file name.
 	 *
 	 * Credits: imvain2.
@@ -570,15 +729,24 @@ class WP_DownloadManager_File {
 		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->downloads} SET file_hits = (file_hits + 1), file_last_downloaded_date = %s WHERE file_id = %d AND file_permission != -2", self::now(), $file_id ) );
 
 		if ( ! self::is_remote( $file_name ) ) {
-			if ( ! is_file( $file_path . $file_name ) ) {
+			/*
+			 * Resolved rather than concatenated. The row's file column is a
+			 * relative path and this endpoint is public, so a row holding
+			 * "/../../wp-config.php" -- however it got written -- must read as
+			 * a missing file rather than as a file. The old is_file() on the
+			 * concatenation answered true for exactly that.
+			 */
+			$real_file = self::safe_file_path( $file_path, $file_name );
+
+			if ( false === $real_file ) {
 				status_header( 404 );
 				wp_die( esc_html__( 'File does not exist.', 'wp-downloadmanager' ), '', array( 'response' => 404 ) );
 			}
 
 			if ( 0 === $method ) {
-				self::send_headers( basename( $file_name ), filesize( $file_path . $file_name ) );
+				self::send_headers( basename( $real_file ), filesize( $real_file ) );
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile -- Streaming the bytes out is what this endpoint is for: readfile() writes straight to the output buffer, so a multi-gigabyte download never has to fit in the PHP memory limit. WP_Filesystem has no streaming read at all - get_contents() returns the whole file as a string.
-				readfile( $file_path . $file_name );
+				readfile( $real_file );
 			} else {
 				// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Sends the visitor to the configured download URL, which is deliberately allowed to be off-site: a CDN or a mirror is the normal reason to choose this method over streaming. wp_safe_redirect() would send every one of those visitors to the dashboard instead.
 				wp_redirect( $file_url . $file_name );
@@ -586,16 +754,52 @@ class WP_DownloadManager_File {
 			self::finish();
 		}
 
+		/*
+		 * Checked again here, and not only when the row was saved. What the
+		 * host resolves to can change between the two, the row may predate the
+		 * check, and a row can be written by something that never passed
+		 * through the Add File screen at all.
+		 */
+		if ( ! self::is_remote_valid( $file_name ) ) {
+			status_header( 404 );
+			wp_die( esc_html__( 'File does not exist.', 'wp-downloadmanager' ), '', array( 'response' => 404 ) );
+		}
+
 		if ( ini_get( 'allow_url_fopen' ) && 0 === $method ) {
 			$file_size = self::remote_filesize( $file_name );
 			self::send_headers( basename( $file_name ), __( 'unknown', 'wp-downloadmanager' ) === $file_size ? 0 : $file_size );
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile -- $file_name is an http(s) URL here, so this proxies a remote file through to the client a chunk at a time. WP_Filesystem does not read URLs, and wp_remote_get() would buffer the entire remote file in memory first.
-			readfile( $file_name );
+			readfile( $file_name, false, self::remote_stream_context() );
 		} else {
 			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- $file_name is the off-site URL the file is stored at; handing the visitor to it is the whole of this branch. wp_safe_redirect() rejects any host but this one, so it would send every remote download to the dashboard.
 			wp_redirect( $file_name );
 		}
 		self::finish();
+	}
+
+	/**
+	 * The stream context a proxied remote download is read through.
+	 *
+	 * Redirects are not followed, and that is the point of the method existing.
+	 * The host check in is_remote_valid() is made against the URL the row holds,
+	 * and PHP's HTTP wrapper follows redirects on its own by default -- so
+	 * without this an allowed host answers 302 and sends the read somewhere the
+	 * check would have refused, which puts the port allow list back to nothing
+	 * too.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return resource
+	 */
+	protected static function remote_stream_context() {
+		return stream_context_create(
+			array(
+				'http' => array(
+					'follow_location' => 0,
+					'timeout'         => 30,
+				),
+			)
+		);
 	}
 
 	/**

--- a/tests/test-admin-writes.php
+++ b/tests/test-admin-writes.php
@@ -193,6 +193,11 @@ class WP_DownloadManager_Admin_Writes_Test extends WP_DownloadManager_TestCase {
 	public function test_adding_a_remote_file_stores_the_url_it_was_given() {
 		global $wpdb;
 
+		// A remote file is now refused when its host resolves onto this network,
+		// which means the check makes a DNS lookup. Stubbed here so the suite
+		// does not need working DNS to answer a question about the Add screen.
+		add_filter( 'wp_downloadmanager_host_is_public', '__return_true' );
+
 		$this->render(
 			array( 'WP_DownloadManager_Admin', 'render_add' ),
 			array(),

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -385,9 +385,180 @@ class WP_DownloadManager_Security_Test extends WP_DownloadManager_TestCase {
 	}
 
 	public function test_a_remote_url_cannot_be_used_for_server_side_request_forgery() {
-		foreach ( array( 'file:///etc/passwd', 'gopher://127.0.0.1:11211/', 'http://127.0.0.1:22/' ) as $candidate ) {
+		$candidates = array(
+			// Refused on scheme or port.
+			'file:///etc/passwd',
+			'gopher://127.0.0.1:11211/',
+			'http://127.0.0.1:22/',
+			// Refused on where the host resolves to, which is the only thing
+			// standing between the endpoint and these: every one of them passes
+			// the scheme test, and an absent port skips the port test entirely.
+			'http://127.0.0.1/',
+			'http://localhost/admin',
+			'http://169.254.169.254/latest/meta-data/',
+			'http://10.0.0.1/',
+			'http://192.168.1.1/',
+			'http://172.16.0.1/',
+			'https://[::1]/',
+		);
+
+		foreach ( $candidates as $candidate ) {
 			$this->assertFalse( WP_DownloadManager_File::is_remote_valid( $candidate ), $candidate . ' should be refused' );
 		}
+	}
+
+	public function test_a_remote_url_on_a_public_host_is_still_allowed() {
+		// Stubbed rather than resolved: the assertion is about the plugin's
+		// decision, and a suite that needs working DNS to make it fails on an
+		// offline runner for a reason that has nothing to do with the plugin.
+		add_filter(
+			'wp_downloadmanager_host_is_public',
+			static function ( $is_public, $host ) {
+				return 'mirror.example.com' === $host ? true : $is_public;
+			},
+			10,
+			2
+		);
+
+		$this->assertTrue(
+			WP_DownloadManager_File::is_remote_valid( 'https://mirror.example.com/brochure.pdf' ),
+			'A remote file on a public host is the feature, and it still works.'
+		);
+	}
+
+	/**
+	 * The Browse source stores a path relative to the downloads directory, so it
+	 * cannot be reduced with basename(), and rename_file()'s character filter
+	 * keeps "." and "/" because a relative path needs them. Nothing else stood
+	 * between a hand-crafted POST and the download endpoint's readfile().
+	 */
+	public function test_a_browse_file_name_cannot_escape_the_downloads_directory() {
+		$refused = array(
+			'/../../../wp-config.php',
+			'../wp-config.php',
+			'sub/../../etc/passwd',
+			"/sub/\0/../..",
+			'//evil.example.com/share',
+		);
+
+		foreach ( $refused as $candidate ) {
+			$this->assertFalse(
+				WP_DownloadManager_File::is_safe_relative_file( $candidate ),
+				$candidate . ' must not be storable as a download'
+			);
+		}
+
+		$allowed = array( '/brochure.pdf', '/sub/brochure.pdf', 'brochure.pdf', '/release..2.zip' );
+
+		foreach ( $allowed as $candidate ) {
+			$this->assertTrue(
+				WP_DownloadManager_File::is_safe_relative_file( $candidate ),
+				$candidate . ' is an ordinary download and must still be storable'
+			);
+		}
+	}
+
+	public function test_the_add_screen_refuses_a_browse_file_name_that_escapes() {
+		global $wpdb;
+
+		$this->become_download_admin();
+		$this->on_admin_screen();
+
+		$before = $this->count_files();
+
+		$this->render(
+			array( 'WP_DownloadManager_Admin', 'render_add' ),
+			array(),
+			array_merge(
+				array(
+					'do'              => 'Add File',
+					'_wpnonce'        => $this->nonce( 'wp_downloadmanager_add' ),
+					'file_type'       => '0',
+					'file'            => '/../../../wp-config.php',
+					'file_name'       => 'Config',
+					'file_cat'        => '1',
+					'file_permission' => '-1',
+				)
+			)
+		);
+
+		$this->assertSame( $before, $this->count_files(), 'The row was refused rather than written.' );
+	}
+
+	/**
+	 * The write path is now closed, so this is about the rows that predate it --
+	 * and about anything that writes the table without going through the screen.
+	 */
+	public function test_the_endpoint_refuses_a_row_whose_file_escapes_the_downloads_directory() {
+		WP_DownloadManager_Options::set( 'path.dir', WP_CONTENT_DIR . '/dm-security' );
+		WP_DownloadManager_Options::set( 'method', 0 );
+
+		// The downloads directory, and a file that is deliberately *outside* it
+		// but really does exist. That last part is the whole test: pointed at a
+		// path that resolves to nothing, the endpoint answers 404 whether or not
+		// it confines anything, and the assertion below would hold for a plugin
+		// with no fix in it at all.
+		$this->make_download_file( 'keep.txt' );
+		$outside = WP_CONTENT_DIR . '/dm-outside-secret.txt';
+		$this->filesystem()->put_contents( $outside, 'DB_PASSWORD would be here' );
+
+		$file_id = $this->insert_file(
+			array(
+				'file'            => '/../dm-outside-secret.txt',
+				'file_name'       => 'Secret',
+				'file_permission' => -1,
+			)
+		);
+
+		$this->assertFileExists( $outside, 'The target exists, so a 404 can only come from the confinement.' );
+
+		$served = false;
+		add_action(
+			'wp_downloadmanager_served',
+			static function () use ( &$served ) {
+				$served = true;
+				throw new WPDieException( 'served' );
+			}
+		);
+
+		set_query_var( 'dl_id', $file_id );
+
+		$message = '';
+
+		try {
+			WP_DownloadManager_File::serve();
+			$this->fail( 'the endpoint should have ended the request' );
+		} catch ( WPDieException $e ) {
+			$message = $e->getMessage();
+		}
+
+		$this->assertFalse( $served, 'A row climbing out of the downloads directory must not be served.' );
+		$this->assertStringContainsString( 'File does not exist', $message, 'It reads as a missing file rather than as a file.' );
+
+		$this->filesystem()->delete( $outside );
+		$this->remove_download_files();
+	}
+
+	public function test_safe_file_path_resolves_a_real_download_and_refuses_a_climb() {
+		WP_DownloadManager_Options::set( 'path.dir', WP_CONTENT_DIR . '/dm-security' );
+		$this->make_download_file( 'sub/keep.txt' );
+
+		$path = WP_DownloadManager_Options::get( 'path.dir' );
+
+		$this->assertNotFalse(
+			WP_DownloadManager_File::safe_file_path( $path, '/sub/keep.txt' ),
+			'A real file inside the downloads directory resolves.'
+		);
+		$this->assertFalse(
+			WP_DownloadManager_File::safe_file_path( $path, '/sub/../../../wp-config.php' ),
+			'A name that climbs out does not, even when the target exists.'
+		);
+		$this->assertFalse(
+			WP_DownloadManager_File::safe_file_path( $path, '/sub/missing.txt' ),
+			'And a name inside the directory that is not a file is not one.'
+		);
+
+		$this->remove_download_files();
 	}
 
 	public function test_the_search_highlight_cannot_be_used_to_inject_markup() {


### PR DESCRIPTION
Two holes, both reachable by whoever holds manage_downloads -- a capability
the plugin exists to hand to an editor without handing over the dashboard.

The Browse source stored whatever file name was posted. The stored name is a
path relative to the downloads directory, so it cannot be reduced with
basename(), and rename_file()'s character filter keeps "." and "/" because a
relative path needs both -- so "/../../../wp-config.php" reached the row
unchanged, and serve() read the row's path with readfile() and no
confinement. Add File refuses such a name now, and the endpoint resolves the
path and confirms it is inside the downloads directory before reading a
byte, so a row written by anything else is refused too. Download::delete()
has confined for a while, with a comment saying a crafted row cannot make it
unlink elsewhere; the read path was the odd one out.

is_remote_valid() checked scheme and port and nothing else, and the port
test is skipped when the URL carries none -- so
http://169.254.169.254/latest/meta-data/ and http://127.0.0.1/ both passed.
The endpoint proxies a remote file with readfile(), which is a raw stream
wrapper rather than wp_safe_remote_get(), so nothing else on the path made
the check WordPress otherwise would. The host must resolve outside this
network now, every A record is tested rather than the first, it is checked
again when the file is served rather than only when it is saved, and
redirects are not followed -- without which an allowed host answers 302 and
takes the port allow list with it.

wp_downloadmanager_host_is_public is the escape hatch for a mirror that
genuinely is on the local network.
---
Part of a security review across all nineteen plugins. PHPUnit (single-site and multisite), phpcs and, where applicable, vitest and eslint all pass locally; opening this so CI runs the Playwright suite.

Each fix was mutation-tested: the guard was reverted and the suite re-run to confirm the new tests actually fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aLvFGxYRW475ZnGjbLopC